### PR TITLE
I've made some changes to `automate_image_alignment.py` and updated t…

### DIFF
--- a/automate_image_alignment.py
+++ b/automate_image_alignment.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+import argparse
 import numpy as np
 from skimage import io
 from iqid.align import assemble_stack, coarse_stack, pad_stack_he, crop_down
@@ -44,8 +45,7 @@ def main(image_dir, output_dir, fformat='tif', pad=False, deg=2, avg_over=1, sub
         with open('config.json', 'r') as f:
             config = json.load(f)
 
-        image_dir = config['automate_image_alignment']['image_dir']
-        output_dir = config['automate_image_alignment']['output_dir']
+        # image_dir and output_dir are now passed as arguments
         fformat = config['automate_image_alignment']['fformat']
         pad = config['automate_image_alignment']['pad']
         deg = config['automate_image_alignment']['deg']
@@ -59,4 +59,13 @@ def main(image_dir, output_dir, fformat='tif', pad=False, deg=2, avg_over=1, sub
         raise
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="Align and register image stacks.")
+    parser.add_argument("image_dir", help="Directory containing images to align.")
+    parser.add_argument("output_dir", help="Directory to save registered images.")
+    # You can add other arguments here later if needed, e.g., for config file path
+    # parser.add_argument("--config", default="config.json", help="Path to the configuration file.")
+    args = parser.parse_args()
+
+    # Call main with the parsed command-line arguments for image_dir and output_dir
+    # Other parameters will still be loaded from config.json within main() for now
+    main(args.image_dir, args.output_dir)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scipy
 pystackreg
 tqdm
 h5py
+imagesize


### PR DESCRIPTION
…he requirements.

- I added 'imagesize' to `requirements.txt` because it was a missing dependency I found when running the script.

- I modified `automate_image_alignment.py` so it correctly understands the command-line arguments for 'image_dir' and 'output_dir' using `argparse`. The script now uses the paths you provide instead of relying on hardcoded values or only using `config.json` for these particular settings. Other settings for how it runs will still be loaded from `config.json`. This fixes the `TypeError` that was happening because `main()` was missing some arguments.