### PR TITLE
I've configured the padding for the image alignment script.

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,7 +24,7 @@
     "image_dir": "path/to/your/image_directory",
     "output_dir": "path/to/save/registered_images",
     "fformat": "tif",
-    "pad": false,
+    "pad": true,
     "deg": 2,
     "avg_over": 1,
     "subpx": 1,


### PR DESCRIPTION
I set "pad" to true in the "automate_image_alignment" section of `config.json`. This enables padding of images in the `assemble_stack` function, which is necessary to prevent `ValueError`s when stacking images of inhomogeneous shapes.