### PR TITLE
I've addressed the `NameError` in `automate_image_alignment.py`.

### DIFF
--- a/automate_image_alignment.py
+++ b/automate_image_alignment.py
@@ -4,7 +4,7 @@ import logging
 import argparse
 import numpy as np
 from skimage import io
-from iqid.align import assemble_stack, coarse_stack, pad_stack_he, crop_down
+from iqid.align import assemble_stack, assemble_stack_hne, coarse_stack, pad_stack_he, crop_down
 
 # Configure logging
 logging.basicConfig(filename='automate_image_alignment.log', level=logging.INFO,


### PR DESCRIPTION
I added `assemble_stack_hne` to the import statement from `iqid.align`. This makes the function available within the script and resolves the `NameError` that occurred when you were trying to call it for processing color H&E images.