### PR TITLE
I've addressed a NameError in `iqid/align.py` within the `assemble_st…

### DIFF
--- a/iqid/align.py
+++ b/iqid/align.py
@@ -105,7 +105,7 @@ def assemble_stack(imdir=None, fformat='tif', pad=False):
 def assemble_stack_hne(imdir=None, fformat='tif', color=(0, 0, 0), pad=True):
     data_path = os.path.join('.', imdir)
     fileList = glob.glob(os.path.join(data_path, '*.' + fformat))
-    fileList.sort(key=iq.natural_keys)
+    fileList.sort(key=helper.natural_keys)
 
     if pad:
         temp = np.zeros((len(fileList), 2))


### PR DESCRIPTION
…ack_hne` function.

I modified the code to call `helper.natural_keys` instead of `iq.natural_keys`. This change ensures that the imported 'helper' module is correctly used for naturally sorting filenames, resolving the NameError that was occurring.